### PR TITLE
[Feat] order service kafka topic

### DIFF
--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -25,7 +25,11 @@
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>github.jimoou</groupId>
+			<artifactId>base-domains</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/order-service/src/main/java/github/jimoou/orderservice/config/KafkaTopicConfig.java
+++ b/order-service/src/main/java/github/jimoou/orderservice/config/KafkaTopicConfig.java
@@ -1,0 +1,20 @@
+package github.jimoou.orderservice.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+  @Value("${spring.kafka.topic.name}")
+  private String topicName;
+
+  // spring bean for kafka topic
+  @Bean
+  public NewTopic topic() {
+    return TopicBuilder.name(topicName).partitions(3).build();
+  }
+}

--- a/order-service/src/main/java/github/jimoou/orderservice/kafka/OrderProducer.java
+++ b/order-service/src/main/java/github/jimoou/orderservice/kafka/OrderProducer.java
@@ -1,0 +1,38 @@
+package github.jimoou.orderservice.kafka;
+
+import github.jimoou.basedomains.dto.OrderEvent;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderProducer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OrderProducer.class);
+
+  private NewTopic topic;
+
+  private KafkaTemplate<String, OrderEvent> kafkaTemplate;
+
+  public OrderProducer(NewTopic topic, KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+    this.topic = topic;
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  public void sendMessage(OrderEvent event) {
+    LOGGER.info(String.format("Order event => %s", event.toString()));
+
+    // create Message
+    Message<OrderEvent> message =
+        MessageBuilder
+         .withPayload(event)
+         .setHeader(KafkaHeaders.TOPIC, topic.name())
+         .build();
+    kafkaTemplate.send(message);
+  }
+}


### PR DESCRIPTION
OrderService의 Kafka 토픽 설정 생성 @Bean 생성을 이용해 3개의 파티션으로 토픽을 빌드.

`pom.xml`
모듈 종속성 설정을 이용하여.
base-domain의 `OrderEvent`를 사용함.

`OrderProducer`
KafkaTemplate을 이용하여. 메세지를 보내는 sendMessage 메소드를 작성함.