### PR TITLE
[Feat] Create Kafka Consumer

### DIFF
--- a/stock-service/pom.xml
+++ b/stock-service/pom.xml
@@ -36,7 +36,12 @@
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>github.jimoou</groupId>
+            <artifactId>base-domains</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/stock-service/src/main/java/github/jimoou/stockservice/kafka/OrderConsumer.java
+++ b/stock-service/src/main/java/github/jimoou/stockservice/kafka/OrderConsumer.java
@@ -1,0 +1,22 @@
+package github.jimoou.stockservice.kafka;
+
+import github.jimoou.basedomains.dto.OrderEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderConsumer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OrderConsumer.class);
+
+  @KafkaListener(
+      topics = "${spring.kafka.topic.name}",
+      groupId = "${spring.kafka.consumer.group-id}")
+  public void consume(OrderEvent event) {
+      LOGGER.info(String.format("Order event received in stock service => %s", event.toString()));
+
+      // save the order event into the database
+  }
+}

--- a/stock-service/stock-service.iml
+++ b/stock-service/stock-service.iml
@@ -135,5 +135,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-launcher:1.9.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.9.3" level="project" />
+    <orderEntry type="module" module-name="base-domains" />
   </component>
 </module>


### PR DESCRIPTION
`OrderConsumer`
클래스 생성하여.
Order Service이벤트를 구독함.
튜토리얼 코드여서 Log외에 추가 서비스 로직 코드 없음.

Stock-service에 Order Service모듈 종속성 추가하여 OrderEvent객체 사용.